### PR TITLE
79 group info backend to frontend

### DIFF
--- a/eahub/static/styles/profile.css
+++ b/eahub/static/styles/profile.css
@@ -72,6 +72,12 @@
   color: #A7DBAB; /* EAHub green */
 }
 
+.group-key-facts-sublist ul {
+  background-color: inherit;
+  list-style-type: disc;
+  padding-top: 0px;
+}
+
 .profile-map {
   padding: 10px 10px 10px 10px;
 }

--- a/templates/eahub/group.html
+++ b/templates/eahub/group.html
@@ -48,14 +48,23 @@
           <li><b>Country:</b> {{ group.country }}</li>
         {% endif %}
         {% if group.organisers %}
-          <li><b>Organiser:</b> {{ group.organisers }}</li>
-        {% endif %}
-        {% if group.meetup_details %}
-          <li><b>Meetup details:</b> {{ group.meetup_details }}
-            {% if group.meetup_url %}
-              <a href="{{ group.url }}">Meetup Link</a>
-            {% endif %}
-          </li>
+            <div  class="group-key-facts-sublist">
+            <li>
+              {% if group.organisers.all|length > 1 %}
+              <b>Organisers:</b>
+              <ul>
+                {% for organiser in group.organisers.all %}
+                  <li>{{ organiser }}</li>
+                {% endfor %}
+              </ul>
+              {% else %}
+              <b>Organiser:</b>
+                {% for organiser in group.organisers.all %}
+                  {{ organiser }}
+                {% endfor %}
+              {% endif %}
+            </li>
+            </div>
         {% endif %}
       </ul>
     </div>
@@ -108,6 +117,8 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script>
   var donations = {{ group.donations | safe }}
+  // var organisers = {{ group.organisers.all | safe }}
+  // console.log(organisers);
   donations = donations.donations
   var table_donations = $("#table_donations")
   donations.forEach(function(donation) {

--- a/templates/eahub/group.html
+++ b/templates/eahub/group.html
@@ -48,7 +48,7 @@
           <li><b>Country:</b> {{ group.country }}</li>
         {% endif %}
         {% if group.organisers %}
-            <div  class="group-key-facts-sublist">
+            <div class="group-key-facts-sublist">
             <li>
               {% if group.organisers.all|length > 1 %}
               <b>Organisers:</b>
@@ -57,7 +57,7 @@
                   <li>{{ organiser }}</li>
                 {% endfor %}
               </ul>
-              {% else %}
+              {% elif group.organisers.all|length == 1 %}
               <b>Organiser:</b>
                 {% for organiser in group.organisers.all %}
                   {{ organiser }}

--- a/templates/eahub/group.html
+++ b/templates/eahub/group.html
@@ -109,7 +109,7 @@
   <div class="profile-info">
     <h3>Custom</h3>
     <p>
-      {% group.custom %}
+      {{ group.custom }}
     </p>
   </div>
   {% else %}

--- a/templates/eahub/group.html
+++ b/templates/eahub/group.html
@@ -105,12 +105,21 @@
   </div>
   {% endif %}
 
+  {% if group.custom  %}
   <div class="profile-info">
     <h3>Custom</h3>
     <p>
-      Here's some further info about our group: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+      {% group.custom %}
     </p>
   </div>
+  {% else %}
+  <div class="profile-info">
+    <h3>Custom</h3>
+    <p>
+      This is a dummy text to show what the custom field would look like.
+    </p>
+  </div>
+  {% endif %}
 
 </div>
 


### PR DESCRIPTION
Implements: https://github.com/rtcharity/hubreboot/issues/79

Some examples:
* [Group with summary; country in key facts](https://eahub.azurewebsites.net/group/96) 
* [Group with summary; organiser and website in key facts](https://eahub.azurewebsites.net/group/97)
* [Group with summary; donations; no key facts](https://eahub.azurewebsites.net/group/116) 
* [Group with more than one organiser in key facts](https://eahub.azurewebsites.net/group/94) 

Remarks
* A couple of fields in the key facts that **were** in the wireframes I didn't implemented as they don't exist in the database
* I've implemented a few fields in the key facts that were **not** in the wireframes, which I implemented as they were in the database and seemed useful 