### PR TITLE
Make email case-insensitive in the database

### DIFF
--- a/profiles/migrations/0020_case_insensitive_email.py
+++ b/profiles/migrations/0020_case_insensitive_email.py
@@ -1,0 +1,33 @@
+from django.contrib.postgres import operations
+from django.contrib.postgres.fields import citext
+from django.db import migrations
+from django.db import models
+from django.db.models import functions
+
+
+def delete_duplicate_email_profiles(apps, schema_editor):
+    Profile = apps.get_model("profiles", "Profile")
+    Profile.objects.exclude(
+        id=models.Subquery(
+            Profile.objects.annotate(normalized_email=functions.Lower("email"))
+            .filter(normalized_email=functions.Lower(models.OuterRef("email")))
+            .values(canonical_id=models.Min("id"))
+        )
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("profiles", "0019_auto_20190206_0632")]
+
+    operations = [
+        operations.CITextExtension(),
+        migrations.RunPython(
+            delete_duplicate_email_profiles, hints={"model_name": "profile"}
+        ),
+        migrations.AlterField(
+            model_name="profile",
+            name="email",
+            field=citext.CIEmailField(max_length=254, unique=True),
+        ),
+    ]

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -1,6 +1,6 @@
 import string, csv
 from django.db import models
-from django.contrib.postgres.fields import ArrayField
+from django.contrib.postgres.fields import ArrayField, CIEmailField
 from django.contrib.auth.models import AbstractUser, UserManager
 from django_upload_path.upload_path import auto_cleaned_path_stripped_uuid4
 from geopy.geocoders import Nominatim
@@ -32,7 +32,7 @@ class Profile(AbstractUser):
 
     objects = ProfileManager()
     USERNAME_FIELD = 'email'
-    email = models.EmailField(unique=True)
+    email = CIEmailField(unique=True)
     REQUIRED_FIELDS = []
 
     EXPERTISE_CHOICES = [


### PR DESCRIPTION
Also delete all profiles with duplicate emails.

I don't know how to test this since we can't readily repro the original migration.